### PR TITLE
Fix ringbuffer deallocation

### DIFF
--- a/src/DDLY.cpp
+++ b/src/DDLY.cpp
@@ -121,6 +121,12 @@ struct DDLY : Module {
     hp = 0.f;
   }
 
+  ~DDLY() override {
+    if(ringBuffer){
+      delete[] ringBuffer;
+    }
+  }
+
   void process(const ProcessArgs& args) override {
     float time = params[TIME_PARAM].getValue();
     float feedback = params[FB_PARAM].getValue();

--- a/src/DDLY.cpp
+++ b/src/DDLY.cpp
@@ -361,7 +361,7 @@ struct DDLY : Module {
   void onAdd() override {
     // reallocate ringbuffer
     if(ringBuffer){
-      delete ringBuffer;
+      delete[] ringBuffer;
     }
 
     sampleRate = APP->engine->getSampleRate();
@@ -382,7 +382,7 @@ struct DDLY : Module {
   void onReset() override {
     // reallocate ringbuffer
     if(ringBuffer){
-      delete ringBuffer;
+      delete[] ringBuffer;
     }
 
     sampleRate = APP->engine->getSampleRate();
@@ -407,7 +407,7 @@ struct DDLY : Module {
   void onSampleRateChange() override {
     // reallocate ringbuffer
     if(ringBuffer){
-      delete ringBuffer;
+      delete[] ringBuffer;
     }
 
     sampleRate = APP->engine->getSampleRate();


### PR DESCRIPTION
Error detected by valgrind.
When allocating with `new X[size]` one must use `delete[] x` style of deallocation.
Logs were:
```

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1A0DB3B: DDLY::onAdd() (DDLY.cpp:364)
==869036==    by 0x7702AA: rack::engine::Module::onAdd(rack::engine::Module::AddEvent const&) (Module.hpp:368)
==869036==    by 0x24A4685: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:611)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x21f847e0 is 0 bytes inside a block of size 529,200 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1A0C8DD: DDLY::DDLY() (DDLY.cpp:102)
==869036==    by 0x1A0F015: rack::CardinalPluginModel<DDLY, DDLYWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1A0DD81: DDLY::onSampleRateChange() (DDLY.cpp:410)
==869036==    by 0x770346: rack::engine::Module::onSampleRateChange(rack::engine::Module::SampleRateChangeEvent const&) (Module.hpp:409)
==869036==    by 0x24A46CB: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:616)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x22096040 is 0 bytes inside a block of size 529,200 alloc'd
==869036==    at 0x6E8F2F3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1A0DBA9: DDLY::onAdd() (DDLY.cpp:372)
==869036==    by 0x7702AA: rack::engine::Module::onAdd(rack::engine::Module::AddEvent const&) (Module.hpp:368)
==869036==    by 0x24A4685: rack::engine::Engine::addModule(rack::engine::Module*) (Engine.cpp:611)
==869036==    by 0x6B3B5F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:495)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036== 
```